### PR TITLE
draft_to_ready_no_work_0077

### DIFF
--- a/.terrateam/config.yml
+++ b/.terrateam/config.yml
@@ -1,5 +1,7 @@
 engine:
   name: tofu
+when_modified:
+  autoplan_draft_pr: false
 
 apply_requirements:
   create_completed_apply_check_on_noop: true

--- a/tf1/tf.tf
+++ b/tf1/tf.tf
@@ -1,0 +1,2 @@
+resource "null_resource" "foo" {
+}

--- a/tf2/tf.tf
+++ b/tf2/tf.tf
@@ -1,0 +1,2 @@
+resource "null_resource" "foo" {
+}


### PR DESCRIPTION
When PR transitioning from draft to ready, if no work to autoplan, do not mark apply status check as done