### PR TITLE
config_nonexistent_dir_0085

### DIFF
--- a/.terrateam/config.yml
+++ b/.terrateam/config.yml
@@ -1,2 +1,7 @@
 engine:
   name: tofu
+
+dirs:
+  foobar:
+    when_modified:
+      file_patterns: ['tf/*.tf']

--- a/tf/tf.tf
+++ b/tf/tf.tf
@@ -1,0 +1,2 @@
+resource "null_resource" "foo" {
+}


### PR DESCRIPTION
Configuring a directory that does not exist does not run even if file patterns match